### PR TITLE
Improve loop efficiency

### DIFF
--- a/src/main/java/net/wuerfel21/derpyshiz/items/WuerfeliumSword.java
+++ b/src/main/java/net/wuerfel21/derpyshiz/items/WuerfeliumSword.java
@@ -43,14 +43,12 @@ public class WuerfeliumSword extends DerpySword{
 			boolean found = false;
 			AxisAlignedBB box = AxisAlignedBB.getBoundingBox(entityIn.posX-10,entityIn.posY-5,entityIn.posZ-10,entityIn.posX+10,entityIn.posY+5,entityIn.posZ+10);
 			List list = worldIn.getEntitiesWithinAABB(IMob.class, box);
-			 if (list != null && !list.isEmpty()) {
-				 for (int i=0;i<list.size();i++) {
-					 Entity e = (Entity)list.get(i);
-					 if (e instanceof IMob && !(e instanceof EntityEnderman)) {
-						 found = true;
-					 }
-				 }
-			 }
+			for (int i = 0;i < list.size() && !found; i++) {
+				Entity e = (Entity)list.get(i);
+				if (e instanceof IMob && !(e instanceof EntityEnderman)) {
+					found = true;
+				}
+			}
 			 NBTTagCompound tag = stack.getTagCompound();
 			 if (tag == null) tag = new NBTTagCompound();
 			 tag.setBoolean("active", found);


### PR DESCRIPTION
- World#getEntitiesWithinAABB cannot return null, so no null check needed
- If the list is empty, the for loop will already be skipped, no need to explicitly check
- For loop should break immediately when an entity is found, rather than continuing to loop; this can be done either with a manual 'break' after setting found to true, or by adding it as a condition of the for loop (as I have done here)
